### PR TITLE
Use the domain name instead of full email for ProviderName

### DIFF
--- a/matchers/email_fallback.go
+++ b/matchers/email_fallback.go
@@ -25,7 +25,7 @@ func getRawEmailContacts(rawWhois string) []ProviderContact {
 
 	sortedEmails := make([]ProviderContact, 0, len(emails))
 	for email := range emails {
-		sortedEmails = append(sortedEmails, AbuseEmail{ProviderName(email), email})
+		sortedEmails = append(sortedEmails, AbuseEmail{Email: email})
 	}
 	sort.Slice(sortedEmails, func(i, j int) bool {
 		return sortedEmails[i].(AbuseEmail).Email < sortedEmails[j].(AbuseEmail).Email

--- a/matchers/types.go
+++ b/matchers/types.go
@@ -1,5 +1,9 @@
 package matchers
 
+import (
+	"strings"
+)
+
 type ProviderContact interface {
 	Name() string // Returns a Name that uniquely identifies the recipient of an abuse report
 }
@@ -12,6 +16,22 @@ type OnlineForm struct {
 type AbuseEmail struct {
 	ProviderName
 	Email string
+}
+
+func (a AbuseEmail) Name() string {
+	// Use a nice provider names if given
+	if a.ProviderName != "" {
+		return a.ProviderName.Name()
+	}
+
+	// Otherwise attempt to split out the domain from the email
+	emailParts := strings.SplitN(a.Email, "@", 2)
+	if len(emailParts) > 1 {
+		return emailParts[1]
+	}
+
+	// Fall back to just the email itself
+	return a.Email
 }
 
 type ProviderName string


### PR DESCRIPTION
`abuse@hostingprovider.com` isn't a good default name, just `hostingprovider.com` is much better

If no explicit name is given, the Name() function will attempt to do this name extraction from the abuse email address